### PR TITLE
Feat/ovos logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# scripts
+## ovos-logs
+ Small helper tool to quickly navigate the logs, create slices and quickview errors  
+
+---------------
+- **ovos-logs slice [options]**
+
+  **Slice logs of a given time period. Defaults on the last service start (`-s`) until now (`-u`)**
+
+  _Different logs can be picked using the `-l` option. All logs will be included if not specified._  
+  _Optionally, the directory where the logs are stored (`-d`) and the file where the slices should be dumped (`-f`) can be passed as arguments._  
+
+  <sup>[ex: `ovos-logs slice`]</sup>  
+  Slice all logs from service start up until now.
+
+  <sup>[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25`]</sup>  
+  Slice all logs from 17:05:20 until 17:05:25.
+
+  <sup>[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25 -l bus -l skills`]</sup>  
+  Slice the logs from 17:04:20 until 17:04:25 (bus.log/skills.log).
+
+  <sup>[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25 -f ~/testslice.log`]</sup>  
+  Slice the logs from 17:04:20 until 17:04:25 on all log files and dump the slices in the file ~/testslice.log (default: ~/slice.log).
+--------------
+
+- **ovos-logs list [-e|-w|-d|-x] [options]**
+
+  **List logs by level (a log level has to be specified, more than one can be listed)**  
+
+  _A start and end date can be specified using the `-s` and `-u` options. Defaults to the last service start until now._  
+  _Different logs can be picked using the `-l` option. All logs will be included if not specified._  
+  _Optionally, the directory where the logs are stored (`-d`) and the file where the slices should be dumped (`-f`) can be passed as arguments._  
+
+  <sup>[ex: `ovos-logs list -x`]</sup>  
+  List the logs with level EXCEPTION (plus tracebacks) from the last service start until now.
+
+  <sup>[ex: `ovos-logs list -w -e -s 20-12-2023 -l bus -l skills`]</sup>  
+  List the logs with level WARNING and ERROR from the 20th of December 2023 until now from the logs bus.log and skills.log.
+
+---------------------
+- **ovos-logs show -l [servicelog]**
+
+  **Show logs**
+
+  <sup>[ex: `ovos-logs show -l bus`]</sup>  
+  Show the logs from bus.log.
+
+  <sup>[ex: wrong servicelog]</sup>  

--- a/README.md
+++ b/README.md
@@ -10,39 +10,49 @@
   _Different logs can be picked using the `-l` option. All logs will be included if not specified._  
   _Optionally, the directory where the logs are stored (`-d`) and the file where the slices should be dumped (`-f`) can be passed as arguments._  
 
-  <sup>[ex: `ovos-logs slice`]</sup>  
-  Slice all logs from service start up until now.
-
-  <sup>[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25`]</sup>  
-  Slice all logs from 17:05:20 until 17:05:25.
-
-  <sup>[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25 -l bus -l skills`]</sup>  
-  Slice the logs from 17:04:20 until 17:04:25 (bus.log/skills.log).
-
-  <sup>[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25 -f ~/testslice.log`]</sup>  
-  Slice the logs from 17:04:20 until 17:04:25 on all log files and dump the slices in the file ~/testslice.log (default: ~/slice.log).
+  _[ex: `ovos-logs slice`]_  
+  <sup>_Slice all logs from service start up until now. (not shown)_</sup>
+  
+  _[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25`]_  
+  <sup>_Slice all logs from 17:05:20 until 17:05:25._</sup>    
+  <sup>_**no logs in that timeframe in other present logs_</sup>
+  <img width="1898" alt="Screenshot 2023-12-25 185004" src="https://github.com/emphasize/scripts/assets/25036977/63ae2123-05d5-4044-be7c-4fe9af10e076">
+   
+  _[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25 -l skills`]_  
+  <sup>_Slice skills.log from 17:04:20 until 17:04:25._</sup>
+  <img width="1239" alt="Screenshot 2023-12-25 200705" src="https://github.com/emphasize/scripts/assets/25036977/39893908-5b85-4261-8f08-81938690edc8"> 
+  
+  _[ex: `ovos-logs slice -s 17:05:20 -u 17:05:25 -f ~/testslice.log`]_  
+  <sup>_Slice the logs from 17:04:20 until 17:04:25 on all log files and dump the slices in the file ~/testslice.log (default: ~/slice.log)._</sup>
+  <img width="1433" alt="Screenshot 2023-12-25 190521" src="https://github.com/emphasize/scripts/assets/25036977/db0dfd16-87e0-4eaf-abc3-bccf95cb23b5">
+  <img width="1246" alt="Screenshot 2023-12-25 190732" src="https://github.com/emphasize/scripts/assets/25036977/23deb4d1-714d-4ba5-a2cb-4173352568c0">
 --------------
 
 - **ovos-logs list [-e|-w|-d|-x] [options]**
 
-  **List logs by level (a log level has to be specified, more than one can be listed)**  
+  **List logs by severity (error/warning/debug/exception). A log level has to be specified - more than one can be listed**  
 
   _A start and end date can be specified using the `-s` and `-u` options. Defaults to the last service start until now._  
   _Different logs can be picked using the `-l` option. All logs will be included if not specified._  
   _Optionally, the directory where the logs are stored (`-d`) and the file where the slices should be dumped (`-f`) can be passed as arguments._  
 
-  <sup>[ex: `ovos-logs list -x`]</sup>  
-  List the logs with level EXCEPTION (plus tracebacks) from the last service start until now.
+  _[ex: `ovos-logs list -x`]_  
+  <sup>_List the logs with level EXCEPTION (plus tracebacks) from the last service start until now._</sup>
+  <img width="992" alt="Screenshot 2023-12-25 184321" src="https://github.com/emphasize/scripts/assets/25036977/7e67ee30-7b34-4645-8e8c-e11622c5226d">
 
-  <sup>[ex: `ovos-logs list -w -e -s 20-12-2023 -l bus -l skills`]</sup>  
-  List the logs with level WARNING and ERROR from the 20th of December 2023 until now from the logs bus.log and skills.log.
-
+  _[ex: `ovos-logs list -w -e -s 20-12-2023 -l bus -l skills`]_  
+  <sup>_List the logs with level WARNING and ERROR from the 20th of December 2023 until now from the logs bus.log and skills.log._</sup>
+  <img width="1898" alt="Screenshot 2023-12-25 173739" src="https://github.com/emphasize/scripts/assets/25036977/4c3d8d59-8886-444d-aaa8-3bfc57dd31b7">
 ---------------------
+
 - **ovos-logs show -l [servicelog]**
 
   **Show logs**
 
-  <sup>[ex: `ovos-logs show -l bus`]</sup>  
-  Show the logs from bus.log.
+  _[ex: `ovos-logs show -l bus`]_  
+  <sup>_Show the logs from bus.log. (not shown)_</sup>  
 
-  <sup>[ex: wrong servicelog]</sup>  
+  _[ex: wrong servicelog]_  
+  <sup>_**logs shown depending on the logs present in the folder_</sup>
+  <img width="1900" alt="Screenshot 2023-12-25 190910" src="https://github.com/emphasize/scripts/assets/25036977/085fac17-c58a-4a9b-8acb-b5a948903b6e">
+  

--- a/ovos-logs
+++ b/ovos-logs
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+
+import re
+import os
+from pathlib import Path
+from datetime import datetime
+from traceback import FrameSummary
+from typing import Any, Tuple, List, Generator, Dict, Union, Optional
+from dataclasses import dataclass
+
+from dateutil.parser import parse
+import rich_click as click
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.style import Style
+from rich.table import Table
+import pydoc
+
+from ovos_config import Configuration
+
+try:
+    from ovos_config.meta import get_xdg_base
+    default_base = get_xdg_base()
+except ImportError:
+    default_base = os.environ.get("OVOS_CONFIG_BASE_FOLDER") or \
+        "mycroft"
+from ovos_utils.xdg_utils import xdg_state_home
+
+DEFAULT_LOG_DIR = Configuration().get("path", os.path.join(xdg_state_home(), default_base))
+DEFAULT_SLICE_FILE = os.path.join(os.path.expanduser("~"), "slice.log")
+PRESENT_LOGS = [Path(f).stem.replace("_", "-") for f in os.listdir(DEFAULT_LOG_DIR)
+                if Path(f).suffix == ".log"]
+ALL_SERVICES = ["bus",
+                "audio",
+                "skills",
+                "voice",
+                "gui",
+                "ovos",
+                "phal",
+                "phal-admin",
+                "hivemind",
+                "hivemind-voice-sat"]
+
+use24h = Configuration().get("time_format", "full") == "full"
+date_format = Configuration().get("date_format", "DMY")
+EXPECTED_DATE_FORMAT = "YYYY-MM-DD" if date_format == "YMD" else "DD-MM-YYYY"
+EXPECTED_DATE = "2021-02-01" if date_format == "YMD" else "01-02-2021"
+EXPECTED_DATETIME_FORMAT = f"[{EXPECTED_DATE_FORMAT}] HH:MM[:SS] {'AM/PM' if not use24h else ''}"
+
+LOGSOPTHELP = """logs to be sliced 
+\nmultiple: -l bus -l audio"""
+STARTTIMEHELP = f"""start time of the log slice (default: since service restart, input format: {EXPECTED_DATETIME_FORMAT})
+\n   Example: -s \"{EXPECTED_DATE} 12:00{' AM/PM' if not use24h else ''}\" / -s 12:00:05{' AM/PM' if not use24h else ''}"""
+
+click.rich_click.STYLE_ARGUMENT = "dark_red"
+click.rich_click.STYLE_OPTION = "dark_red"
+click.rich_click.STYLE_SWITCH = "indian_red"
+console = Console()
+
+
+@dataclass
+class LogLine:
+    timestamp: datetime = None
+    source: str = ""
+    location: str = ""
+    level: str = ""
+    message: str = ""
+
+    def __str__(self):
+        return " - ".join(str(elem) for elem in self.__dict__.values() if elem)
+
+# Traceback frame
+class Frame(FrameSummary):
+    def __init__(self, filename, lineno, name, line):
+        super().__init__(filename, lineno, name, line=line)
+      
+    def as_dict(self):
+        return {
+            "location": self.format_location(),
+            "level": "TRACEBACK",
+            "message": self.line
+        }
+    
+    def as_logline(self):
+        return LogLine(**self.as_dict())
+    
+    def format_location(self):
+        if "site-packages" not in self.filename and \
+                (pyver := re.search(r"python\d\.\d+[\\/]", self.filename)):
+            package = self.filename.split(pyver.group())[-1].replace(".py", "")\
+                    .replace("-", "_").replace("/", ".")
+        else:
+            package = self.filename.split("site-packages/")[-1].replace(".py", "")\
+                    .replace("-", "_").replace("/", ".")
+        method = self.name.replace(".py", "").replace("-", "_")
+        return f"{package}:{method}:{self.lineno}"
+
+
+class Traceback:
+    PATTERN = r'File "(?P<filename>[^"]+)", line (?P<lineno>\d+), in (?P<name>\w+)\n\s*(?P<line>.+)'
+
+    def __init__(self, frames: List[Frame], exception: str, timestamp: datetime = None):
+        self.frames = frames
+        self.exception = exception
+        self._timestamp = timestamp
+    
+    @property
+    def exception_location(self):
+        return self.frames[-1].format_location()
+    
+    @property
+    def timestamp(self):
+        return self._timestamp
+    
+    @timestamp.setter
+    def timestamp(self, value):
+        self._timestamp = value
+
+    def to_loglines(self) -> List[LogLine]:
+        
+        lines = [LogLine(timestamp=self.timestamp,
+                         location=self.exception_location,
+                         level="EXCEPTION",
+                         message=self.exception)]
+
+        for frame in self.frames:
+            lines.append(frame.as_logline())
+        
+        return lines
+
+    @classmethod
+    def from_list(cls, lines):
+        lines = [line if line.endswith("\n") else line + "\n" for line in lines]
+        multiline = "".join(lines)
+        return cls.from_string(multiline)
+    
+    @classmethod
+    def from_string(cls, s):
+        matches = re.findall(cls.PATTERN, s, re.MULTILINE)
+        frames = []
+        for match in matches:
+            data = dict(zip(["filename", "lineno", "name", "line"], match))
+            frames.append(Frame(**data))
+        exception = next(line for line in s.split("\n")[::-1] if line)
+        return cls(frames, exception)
+
+
+class OVOSLogParser:
+    LOG_PATTERN = r'(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) - (?P<source>.+?) - (?P<location>.+?) - (?P<level>\w+) - (?P<message>.*)'
+    TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
+
+    @classmethod
+    def parse(self, log_line, last_timestamp=None) -> LogLine:
+        match = re.match(self.LOG_PATTERN, log_line)
+        data = {}
+        if match:
+            data = match.groupdict()
+            data['timestamp'] = datetime.strptime(data['timestamp'], self.TIME_FORMAT)
+            return LogLine(**data)
+        
+        data["timestamp"] = last_timestamp or ""
+        data["message"] = log_line
+        return LogLine(**data)
+    
+    @classmethod
+    def parse_file(self, file_path) -> Generator[Union[LogLine, Traceback], None, None]:
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File {file_path} does not exist")
+
+        with open(file_path, 'r') as file:
+            trace = None
+            last_timestamp = None
+            for line in file:
+                # gather all lines of the traceback
+                if line == "Traceback (most recent call last):\n":
+                    trace = [line]
+                    continue
+                elif trace and line == "\n":
+                    trace.append(line)
+                    traceback = Traceback.from_list(trace)
+                    traceback.timestamp = last_timestamp
+                    yield traceback
+                    # for log in traceback.to_log():
+                    #     yield log
+                    trace = None
+                elif trace:
+                    trace.append(line)
+                else:
+                    log = self.parse(line, last_timestamp)
+                    if log.message == "\n":
+                        continue
+                    timestamp = log.timestamp
+                    if timestamp:
+                        last_timestamp = timestamp
+                    yield log
+
+
+def get_last_load_time(directory):
+    with open(os.path.join(directory,"skills.log"), "r") as f:
+        for line in f.readlines()[::-1]:
+            logline = OVOSLogParser.parse(line)
+            if logline.message == "Loading message bus configs":
+                return logline.timestamp
+    return None
+
+
+def valid_log(logs):
+    for log in logs:
+        if log.lower() not in PRESENT_LOGS:
+            return False
+    return True
+
+
+def parse_time(time_str):
+    try:
+        time = parse(time_str)
+    except ValueError:
+        return None
+    return time
+
+
+def parse_timeframe(start, end, directory) -> Tuple[Any, Any]:
+    if start is None:
+        start = get_last_load_time(directory)
+    else:
+        start = parse_time(start)
+    
+    if end is None:
+        end = datetime.now()
+    else:
+        end = parse_time(end)
+    return start, end
+
+
+@click.group()
+def ovos_logs():
+    """\b
+    Small helper tool to quickly navigate the logs, create slices and quickview errors
+
+    `ovos-logs [COMMAND] --help` for further information about the specific command ARGUMENTS
+    \b
+    """
+    pass
+
+@ovos_logs.command()
+@click.option("--start", "-s", help=STARTTIMEHELP)
+@click.option("--until", "-u", help=f"end time of the log slice [default: now]")
+@click.option("--logs", "-l", multiple=True, default=PRESENT_LOGS or ALL_SERVICES, help=LOGSOPTHELP, show_default=True)
+@click.option("--dir", "-d", default=DEFAULT_LOG_DIR, help=f"the directory logs reside in", show_default=True)
+@click.option("--file", "-f", is_flag=False, flag_value=DEFAULT_SLICE_FILE, default=None, help=f"output as file (if flagged, but not specified: {DEFAULT_SLICE_FILE})")
+def slice(start, until, logs, dir, file):
+    """\b
+    Slice logs by time
+
+    Different logs can be included using the -l option. If not specified, all logs will be included.
+    Optionally the directory where the logs are stored and the file where the slices should be dumped
+    can be specified.
+    \b
+    """
+    global PRESENT_LOGS
+    if not os.path.exists(dir):
+        return console.print(f"Directory [{dir}] does not exist")
+    elif dir != DEFAULT_LOG_DIR:
+        PRESENT_LOGS = [Path(f).stem.replace("_", "-") for f in os.listdir(dir)
+                        if Path(f).suffix == ".log"]
+
+    start, end = parse_timeframe(start, until, dir)
+    if end is None or start is None:
+        return console.print(f"Need a valid end time in the format ")
+    elif start > end:
+        return console.print(f"Start time [{start}] is after end time [{end}]")
+
+    if not logs:
+        logs = PRESENT_LOGS
+    elif not valid_log(logs):
+        return console.print(f"Invalid log name, valid logs are {PRESENT_LOGS}")
+
+    _templog: Dict[str, List[LogLine]] = dict()
+
+    for service in logs:
+        logfile = os.path.join(dir, f"{service}.log")
+        if not os.path.exists(logfile):
+            continue
+        _templog[service] = []
+        for log in OVOSLogParser.parse_file(logfile):
+            if start <= log.timestamp < end:
+                if isinstance(log, Traceback):
+                    _templog[service].extend(log.to_loglines())
+                else:
+                    _templog[service].append(log)
+        if not _templog[service]:
+            del _templog[service]
+
+    if not _templog:
+        return console.print("No logs found in the specified time frame")
+    
+    if file:
+        console.print(f"Log slice saved to [bold]{file}[/bold]")
+        with open(file, 'w') as f:
+            pass
+
+    for service in _templog:
+        table = Table(title=service)
+        table.add_column("Time", style="cyan", no_wrap=True)
+        table.add_column()
+        table.add_column("Message", style="magenta")
+        table.add_column("Origin", style="green")
+        lineno = 0
+        for logline in _templog[service]:
+            lineno += 1
+            style = None
+            timestamp = logline.timestamp or ""
+            if isinstance(timestamp, datetime):
+                timestamp = timestamp.strftime("%H:%M:%S.%f" if use24h else "%I:%M:%S.%f")[:-3]
+                if not use24h:
+                    timestamp += logline.timestamp.strftime(" %p")
+
+            level = logline.level or ""
+            message = logline.message or ""
+            if level == "ERROR":
+                level = "[bold red]" + level[:1]
+            elif level == "EXCEPTION":
+                level = "[bold red]" + level[:3]
+            elif level == "WARNING":
+                level = "[bold yellow]" + level[:1]
+            elif level == "DEBUG":
+                level = "[bold blue]" + level[:1]
+            elif level == "TRACEBACK":
+                level = "[white]" + level[:5]
+                message = "[grey42]" + message
+            elif level == "INFO":
+                level = ""
+                message = "[navajo_white1]" + message
+            if lineno % 2 == 0:
+                style = Style(bgcolor="grey7")
+            table.add_row(
+                timestamp,
+                level,
+                message,
+                logline.location or "",
+                style=style
+            )
+            if len(logline.message) > 200:
+                table.add_row()
+
+        console.print(table)
+        if file:
+            Console(file=open(file, 'a')).print(table)
+
+@ovos_logs.command()
+@click.option("--error", "-e", is_flag=True, help="display error messages")
+@click.option("--warning", "-w", is_flag=True, help="display warning messages")
+@click.option("--exception", "-x", is_flag=True, help="display exceptions")
+@click.option("--debug", "-d", is_flag=True, help="display debug messages")
+@click.option("--start", "-s", help=STARTTIMEHELP)
+@click.option("--until", "-u", help=f"end time of the log slice [default: now]")
+@click.option("--logs", "-l", multiple=True, default=PRESENT_LOGS or ALL_SERVICES, help=LOGSOPTHELP, show_default=True)
+@click.option("--dir", "-d", default=DEFAULT_LOG_DIR, help=f"the directory logs reside in (default: {DEFAULT_LOG_DIR})")
+@click.option("--file", "-f", is_flag=False, flag_value=DEFAULT_SLICE_FILE, default=None, help=f"output as file (if flagged, but not specified: {DEFAULT_SLICE_FILE})")
+def list(error, warning, exception, debug, start, until, logs, dir, file):
+    """\b
+    List logs by level (a log level has to be specified)
+
+    Different logs can be included using the -l option. If not specified, all logs will be included.
+    
+    Optionally the directory where the logs are stored and the file where the slices should be dumped
+    can be specified.
+    \b
+    """
+    global PRESENT_LOGS
+
+    if not any([error, warning, debug, exception]):
+        return console.print("Need at least one of --error, --warning, --exception or --debug")
+    else:
+        log_levels = [lv_str for lv, lv_str in [(error, "ERROR"), (warning, "WARNING"),
+                                                (debug, "DEBUG"), (exception, "EXCEPTION")] if lv]
+    
+    if not os.path.exists(dir):
+        return console.print(f"Directory [{dir}] does not exist")
+    elif dir != DEFAULT_LOG_DIR:
+        PRESENT_LOGS = [Path(f).stem.replace("_", "-") for f in os.listdir(dir)
+                        if Path(f).suffix == ".log"]
+    
+    start, end = parse_timeframe(start, until, dir)
+    if end is None or start is None:
+        return console.print(f"Need a valid end time in the format {EXPECTED_DATETIME_FORMAT}")
+    elif start > end:
+        return console.print(f"Start time [{start}] is after end time [{end}]")
+    
+    if not logs:
+        logs = PRESENT_LOGS
+    elif not valid_log(logs):
+        return console.print(f"Invalid log name, valid logs are {PRESENT_LOGS}")
+    
+    _templog: Dict[str, List[LogLine]] = dict()
+
+    for service in logs:
+        logfile = os.path.join(dir, f"{service}.log")
+        if not os.path.exists(logfile):
+            continue
+        _templog[service] = []
+        for log in OVOSLogParser.parse_file(logfile):
+            if isinstance(log, Traceback):
+                if exception:
+                    _templog[service].extend(log.to_loglines())
+                continue
+            # LOG.exception
+            if exception and log.level == "EXCEPTION":
+                _templog[service].append(log)
+            if error and log.level == "ERROR":
+                _templog[service].append(log)
+            if warning and log.level == "WARNING":
+                _templog[service].append(log)
+            if debug and log.level == "DEBUG":
+                _templog[service].append(log)
+        if not _templog[service]:
+            del _templog[service]
+    
+    if isinstance(file, str):
+        if file.startswith("~"):
+            file = os.path.join(os.path.expanduser("~"), file[1:])
+        # test if file is writable
+        try:
+            with open(file, 'w') as f:
+                pass
+        except:
+            return console.print(f"File [{file}] is not writable")
+        else:
+            console.print(f"Log slice saved to [bold]{file}[/bold]")
+
+    for service in _templog:
+        table = Table(title=f"{service} ({','.join(log_levels)})")
+        # for traceback indication
+        table.add_column("Time", style="cyan", no_wrap=True)
+        if exception or len(log_levels) > 1:
+            table.add_column()
+        table.add_column("Message", style="magenta")
+        table.add_column("Origin", style="green")
+        lineno = 0
+        for log in _templog[service]:
+            style = None
+            lineno += 1
+            timestamp = log.timestamp or ""
+            if timestamp:
+                timestamp = timestamp.strftime("%H:%M:%S.%f" if use24h else "%I:%M:%S.%f")[:-3]
+            if not use24h and timestamp:
+                timestamp += log.timestamp.strftime(" %p")
+            level = log.level.upper()
+            message = log.message.rstrip("\n")
+            if level == "ERROR":
+                level = "[bold red]" + level[:1]
+            elif level == "EXCEPTION":
+                level = "[bold red]" + level[:3]
+            elif level == "WARNING":
+                level = "[bold yellow]" + level[:1]
+            elif level == "DEBUG":
+                level = "[bold blue]" + level[:1]
+            elif level == "TRACEBACK":
+                level = "[white]" + level[:5]
+                message = "[grey42]" + message
+            elif level == "INFO":
+                level = ""
+                message = "[navajo_white1]" + message
+
+            if lineno % 2 == 0:
+                style = Style(bgcolor="grey7")
+            row = [timestamp, level, message, log.location]
+            if not exception and len(log_levels) < 2:
+                row.pop(1)                
+            table.add_row(*row, style=style)
+
+        console.print(table)
+        if file:
+            Console(file=open(file, 'a')).print(table)
+
+    
+@ovos_logs.command()
+@click.option("--log", "-l", required=True, type=click.Choice(PRESENT_LOGS or ALL_SERVICES, case_sensitive=False), help="log to show")
+@click.option("--dir", "-d", default=DEFAULT_LOG_DIR, help=f"the directory logs reside in (default: {DEFAULT_LOG_DIR})")
+def show(log, dir):
+    """\b
+    Show logs
+
+    Different logs can be included using the -l option. If not specified, all logs will be included.
+    Optionally the directory where the logs are stored and the file where the slices should be dumped
+    can be specified.
+    \b
+    """
+    
+    if not os.path.exists(dir):
+        return console.print(f"Directory [{dir}] does not exist")
+    else:
+        log = os.path.join(dir, f"{log.replace('-', '_')}.log")
+    
+    pydoc.pager(open(log).read())
+
+
+if __name__ == "__main__":
+    ovos_logs()


### PR DESCRIPTION
Adds a `ovos-logs` cli to better navigate logs.

By now only a viewer, there are numerous things to add to better manage logs (truncate, split, ...)

Some code migth be better placed in `ovos_utils.log`, but we can move it if wanted.
Please add to the different distributions